### PR TITLE
fix: cstore/cget event ID space

### DIFF
--- a/servicedispatcher.go
+++ b/servicedispatcher.go
@@ -2,6 +2,7 @@ package netdicom
 
 import (
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/bettermedicine/go-netdicom/dimse"
@@ -176,6 +177,8 @@ func newServiceDispatcher(label string) *serviceDispatcher {
 		downcallCh:     make(chan stateEvent, 128),
 		activeCommands: make(map[dimse.MessageID]*serviceCommandState),
 		callbacks:      make(map[int]serviceCallback),
-		lastMessageID:  123,
+		// We're initializing it at a LARGE size because otherwise we can get message ID conflicts in the callback map.
+		// TODO: segregate client-initiated and server-initiated message IDs and their callbacks into separate id spaces.
+		lastMessageID: math.MaxUint16 - (4 * 1024),
 	}
 }


### PR DESCRIPTION
# When merged, this PR will
- fix C-GET for series with more than 122 images in case server-sent C-stores start incrementing their message IDs from 1
## Context

Here's how C-get requests work in the grand scheme of things. To simplify, consider `Client` to be our code and `Server` to be Orthanc.

```mermaid
sequenceDiagram
    participant Client as Client (SCU)
    participant Server as Server (SCP - Orthanc)
    
    Client->>Server: C-GET Request (Request to retrieve a series of DICOM images)
    Server-->>Client: C-GET Response (Status Pending) (Initial response: Sub-operations are starting)
    Server-->>Client: C-STORE Request (Image 1) (Server sends the first image in a C-STORE request)
    Client->>Server: C-STORE Response (Image 1) (Client acknowledges receipt of Image 1)
    Server-->>Client: C-GET Response (Status Pending) (Intermediate response: Sub-operation completed, N-1 remaining)
    Server-->>Client: C-STORE Request (Image 2) (Server sends the next image in a C-STORE request)
    Client->>Server: C-STORE Response (Image 2) (Client acknowledges receipt of Image 2)
    Server-->>Client: C-GET Response (Status Pending) (Intermediate response: Sub-operation completed, N-2 remaining)
    
    loop Repeat for Images 3 to n
        Server-->>Client: C-STORE Request (Image n) (Server sends the nth image in a C-STORE request)
        Client->>Server: C-STORE Response (Image n) (Client acknowledges receipt of Image n)
    end
    
    Server-->>Client: C-GET Response (Final) (Final response: All sub-operations completed, status success/failure)
```

## Problem
Previously, the `lastMessageID` of the `serviceDispatcher` struct was initialized at a hardcoded `123`.

Since outgoing and incoming requests share an event ID space and some pacs systems (eg. Orthanc) start their own C-STORE sequences (incrementing from 1), this caused the following scenario:
- CStore 1 from Orthanc was handled properly
- CStore 2 from Orthanc was handled properly
- ...
- CStore 123 from Orthanc was routed to `upcallCh` instead of being passed to the registered `onCstore` callback
- CStore 124 from orthanc was handled properly
- ...

## Solution
Initialize the outbound C-GET request with a Very Large :tm: message ID

## Caveats

Ideally, the _good_ solution for this issue is segregating the callback maps for client(us to pacs)-initiated and server-initiated(pacs to us) events into separate maps. Since we don't necessarily have the resources to refactor _and_ comprehensively test that however, this will do for now - we're not yet handling connection pooling -> we create a new `serviceuser` (with its own `servicedispatcher`) for every C-Get request we want to make.