### PR TITLE
chore: pass calling/called AE titles down to onCstore callback in connection state object

### DIFF
--- a/ae_parsing_test.go
+++ b/ae_parsing_test.go
@@ -1,0 +1,214 @@
+package netdicom_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"log"
+
+	"github.com/bettermedicine/go-netdicom"
+	"github.com/bettermedicine/go-netdicom/dimse"
+	"github.com/bettermedicine/go-netdicom/sopclass"
+	"github.com/grailbio/go-dicom"
+	"github.com/grailbio/go-dicom/dicomio"
+	"github.com/grailbio/go-dicom/dicomlog"
+	"github.com/grailbio/go-dicom/dicomtag"
+	"github.com/stretchr/testify/assert"
+)
+
+const serverPort = 10400
+const FooClientAETitle = "FOO_CLIENT"
+const FooClientCalledAETitle = "TEST_SCP_FOO"
+const BarClientAETitle = "BAR_CLIENT"
+const BarClientCalledAETitle = "TEST_SCP_BAR"
+
+// the payload we'll be sending.
+// we'll be placing an unique identifier in the
+// patient name field so we can discern whether or not the correct
+// ae titles were used.
+type AETitleParsingTestCase struct {
+	UniquePatientName string
+	CallingAETitle    string
+	CalledAETitle     string
+}
+
+func TestCStore(t *testing.T) {
+	dicomlog.SetLevel(-1)
+	resultsCh := make(chan *AETitleParsingTestCase, 4)
+	defer close(resultsCh)
+
+	// set up a dicom server
+	serverParams := netdicom.ServiceProviderParams{
+		AETitle: "TEST_SCP",
+		CStore: func(connState netdicom.ConnectionState, transferSyntaxUID string,
+			sopClassUID string,
+			sopInstanceUID string,
+			data []byte) dimse.Status {
+			// we parse the file to extract the patient name
+			buffer := bytes.Buffer{}
+			enc := dicomio.NewEncoderWithTransferSyntax(&buffer, transferSyntaxUID)
+			dicom.WriteFileHeader(enc,
+				[]*dicom.Element{
+					dicom.MustNewElement(dicomtag.TransferSyntaxUID, transferSyntaxUID),
+					dicom.MustNewElement(dicomtag.MediaStorageSOPClassUID, sopClassUID),
+					dicom.MustNewElement(dicomtag.MediaStorageSOPInstanceUID, sopInstanceUID),
+				})
+			enc.WriteBytes(data)
+
+			ds, err := dicom.ReadDataSet(&buffer, dicom.ReadOptions{})
+			if err != nil {
+				t.Fatalf("Failed to read dataset in C-STORE handler: %v", err)
+			}
+
+			patientID, err := ds.FindElementByTag(dicomtag.PatientID)
+			if err != nil {
+				t.Fatalf("Failed to find PatientID element: %v", err)
+			}
+
+			result := &AETitleParsingTestCase{
+				UniquePatientName: patientID.Value[0].(string),
+				CalledAETitle:     connState.CalledAETitle,
+				CallingAETitle:    connState.CallingAETitle,
+			}
+			log.Printf("handled name %s", result.UniquePatientName)
+			resultsCh <- result
+			return dimse.Status{Status: dimse.StatusSuccess}
+		},
+	}
+
+	sp, err := netdicom.NewServiceProvider(serverParams, fmt.Sprintf(":%d", serverPort))
+	if err != nil {
+		t.Fatalf("Failed to create service provider: %v", err)
+	}
+	go func() {
+		sp.Run()
+		log.Println("DICOM server started")
+	}()
+	// these will be sent from the same SU.
+	fooClientCases := []AETitleParsingTestCase{
+		{
+			UniquePatientName: "FOO0001",
+			CallingAETitle:    FooClientAETitle,
+			CalledAETitle:     FooClientCalledAETitle,
+		},
+		{
+			UniquePatientName: "FOO0002",
+			CallingAETitle:    FooClientAETitle,
+			CalledAETitle:     FooClientCalledAETitle,
+		},
+	}
+	// these will be separate SU-s.
+	barClientCases := []AETitleParsingTestCase{
+		{
+			UniquePatientName: "BAR0001",
+			CallingAETitle:    BarClientAETitle,
+			CalledAETitle:     BarClientCalledAETitle,
+		},
+		{
+			UniquePatientName: "BAR0002",
+			CallingAETitle:    BarClientAETitle,
+			CalledAETitle:     BarClientCalledAETitle,
+		},
+	}
+	// we add both foo and bar client cases
+	// into a map for easy lookup later.
+	expectedReceives := map[string]AETitleParsingTestCase{}
+	for _, tc := range fooClientCases {
+		expectedReceives[tc.UniquePatientName] = tc
+	}
+	for _, tc := range barClientCases {
+		expectedReceives[tc.UniquePatientName] = tc
+	}
+
+	// lets handle foo first.
+	suParams := netdicom.ServiceUserParams{
+		CalledAETitle:  FooClientCalledAETitle,
+		CallingAETitle: FooClientAETitle,
+		SOPClasses:     sopclass.StorageClasses,
+	}
+	su, err := netdicom.NewServiceUser(suParams)
+	if err != nil {
+		t.Fatalf("Failed to create service user: %v", err)
+	}
+
+	su.Connect(fmt.Sprintf("localhost:%d", serverPort))
+	for _, tc := range fooClientCases {
+		// load fresh dataset from disk
+		ds, err := dicom.ReadDataSetFromFile("./testdata/IM-0001-0003.dcm", dicom.ReadOptions{})
+		if err != nil {
+			t.Fatalf("Failed to read DICOM file: %v", err)
+		}
+		// patch in unique patient name
+		elem, err := ds.FindElementByTag(dicomtag.PatientID)
+		if err != nil {
+			t.Fatalf("Failed to find PatientID element: %v", err)
+		}
+		elem.Value = []interface{}{tc.UniquePatientName}
+		err = su.CStore(ds)
+		if err != nil {
+			t.Fatalf("C-STORE failed for case %s: %v", tc.UniquePatientName, err)
+		}
+	}
+
+	// now for bar client cases - each in their own SU.
+	for _, tc := range barClientCases {
+		suParams := netdicom.ServiceUserParams{
+			CalledAETitle:  tc.CalledAETitle,
+			CallingAETitle: tc.CallingAETitle,
+			SOPClasses:     sopclass.StorageClasses,
+		}
+		su, err := netdicom.NewServiceUser(suParams)
+		if err != nil {
+			t.Fatalf("Failed to create service user: %v", err)
+		}
+
+		su.Connect(fmt.Sprintf("localhost:%d", serverPort))
+		// load fresh dataset from disk
+		ds, err := dicom.ReadDataSetFromFile("./testdata/IM-0001-0003.dcm", dicom.ReadOptions{})
+		if err != nil {
+			t.Fatalf("Failed to read DICOM file: %v", err)
+		}
+		// patch in unique patient name
+		elem, err := ds.FindElementByTag(dicomtag.PatientID)
+		if err != nil {
+			t.Fatalf("Failed to find PatientID element: %v", err)
+		}
+		elem.Value = []interface{}{tc.UniquePatientName}
+		err = su.CStore(ds)
+		if err != nil {
+			t.Fatalf("C-STORE failed for case %s: %v", tc.UniquePatientName, err)
+		}
+	}
+
+	for {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Service provider failed to start in time")
+		case result, ok := <-resultsCh:
+			if !ok {
+				t.Fatalf("results channel closed early")
+			}
+			// we are in a single for loop so we don't need to guard
+			// expectedReceives with a mutex.
+			expected, found := expectedReceives[result.UniquePatientName]
+			if !found {
+				t.Errorf("Received unexpected patient name: %s", result.UniquePatientName)
+			} else {
+				// assert ae titles match expected values.
+				assert.Equal(t, expected.CallingAETitle, result.CallingAETitle,
+					"Calling AE Title mismatch for patient %s", result.UniquePatientName)
+				assert.Equal(t, expected.CalledAETitle, result.CalledAETitle,
+					"Called AE Title mismatch for patient %s", result.UniquePatientName)
+				// remove from map to mark as seen.
+				delete(expectedReceives, result.UniquePatientName)
+			}
+			// if we've seen all expected results, we are done.
+			if len(expectedReceives) == 0 {
+				log.Printf("All expected C-STORE requests received.")
+				return
+			}
+		}
+	}
+}

--- a/ae_parsing_test.go
+++ b/ae_parsing_test.go
@@ -66,7 +66,7 @@ func TestCStore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to find PatientID element: %v", err)
 			}
-
+			log.Printf("Remote address %s", connState.RemoteAddress.String())
 			result := &AETitleParsingTestCase{
 				UniquePatientName: patientID.Value[0].(string),
 				CalledAETitle:     connState.CalledAETitle,

--- a/servicedispatcher.go
+++ b/servicedispatcher.go
@@ -3,6 +3,7 @@ package netdicom
 import (
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/bettermedicine/go-netdicom/dimse"
@@ -27,6 +28,11 @@ type serviceDispatcher struct {
 	// The last message ID used in newCommand(). Used to avoid creating duplicate
 	// IDs.
 	lastMessageID dimse.MessageID
+
+	// AE titles from the association handshake. Set once and reused for all commands.
+	// guarded by mu
+	CalledAETitle  string
+	CallingAETitle string
 }
 
 type serviceCallback func(msg dimse.Message, data []byte, cs *serviceCommandState)
@@ -40,6 +46,10 @@ type serviceCommandState struct {
 
 	// upcallCh streams command+data for this messageID.
 	upcallCh chan upcallEvent
+
+	// AE titles from the association handshake.
+	CalledAETitle  string
+	CallingAETitle string
 }
 
 // Send a command+data combo to the remote peer. data may be nil.
@@ -72,11 +82,13 @@ func (disp *serviceDispatcher) findOrCreateCommand(
 		return cs, true
 	}
 	cs := &serviceCommandState{
-		disp:      disp,
-		messageID: msgID,
-		cm:        cm,
-		context:   context,
-		upcallCh:  make(chan upcallEvent, 128),
+		disp:           disp,
+		messageID:      msgID,
+		cm:             cm,
+		context:        context,
+		upcallCh:       make(chan upcallEvent, 128),
+		CalledAETitle:  disp.CalledAETitle,
+		CallingAETitle: disp.CallingAETitle,
 	}
 	disp.activeCommands[msgID] = cs
 	dicomlog.Vprintf(1, "dicom.serviceDispatcher(%s): Start command %+v", disp.label, cs)
@@ -96,11 +108,13 @@ func (disp *serviceDispatcher) newCommand(
 		}
 
 		cs := &serviceCommandState{
-			disp:      disp,
-			messageID: msgID,
-			cm:        cm,
-			context:   context,
-			upcallCh:  make(chan upcallEvent, 128),
+			disp:           disp,
+			messageID:      msgID,
+			cm:             cm,
+			context:        context,
+			upcallCh:       make(chan upcallEvent, 128),
+			CalledAETitle:  disp.CalledAETitle,
+			CallingAETitle: disp.CallingAETitle,
 		}
 		disp.activeCommands[msgID] = cs
 		disp.lastMessageID = msgID
@@ -134,6 +148,18 @@ func (disp *serviceDispatcher) unregisterCallback(commandField int) {
 
 func (disp *serviceDispatcher) handleEvent(event upcallEvent) {
 	if event.eventType == upcallEventHandshakeCompleted {
+		// Store AE titles in dispatcher for use in all commands on this association
+		disp.mu.Lock()
+		// these are 16 bytes wide and space padded by default
+		// so lets trim spaces
+		disp.CalledAETitle = strings.TrimSpace(event.CalledAETitle)
+		disp.CallingAETitle = strings.TrimSpace(event.CallingAETitle)
+		// Update all existing commands with the AE titles
+		for _, cs := range disp.activeCommands {
+			cs.CalledAETitle = event.CalledAETitle
+			cs.CallingAETitle = event.CallingAETitle
+		}
+		disp.mu.Unlock()
 		return
 	}
 	doassert(event.eventType == upcallEventData)
@@ -154,8 +180,14 @@ func (disp *serviceDispatcher) handleEvent(event upcallEvent) {
 	}
 	disp.mu.Lock()
 	cb := disp.callbacks[event.command.CommandField()]
+	// Get AE titles from dispatcher (set during handshake)
+	calledAE := disp.CalledAETitle
+	callingAE := disp.CallingAETitle
 	disp.mu.Unlock()
 	go func() {
+		// Update AE titles on the command state from dispatcher
+		dc.CalledAETitle = calledAE
+		dc.CallingAETitle = callingAE
 		cb(event.command, event.data, dc)
 		disp.deleteCommand(dc)
 	}()

--- a/serviceprovider.go
+++ b/serviceprovider.go
@@ -392,6 +392,7 @@ type ConnectionState struct {
 	TLS            tls.ConnectionState
 	CalledAETitle  string
 	CallingAETitle string
+	RemoteAddress  net.Addr
 }
 
 // CEchoCallback implements C-ECHO callback. It typically just returns
@@ -483,6 +484,7 @@ func NewServiceProvider(params ServiceProviderParams, port string) (*ServiceProv
 }
 
 func getConnState(conn net.Conn) (cs ConnectionState) {
+	cs.RemoteAddress = conn.RemoteAddr()
 	tlsConn, ok := conn.(*tls.Conn)
 	if ok {
 		cs.TLS = tlsConn.ConnectionState()

--- a/serviceprovider.go
+++ b/serviceprovider.go
@@ -27,6 +27,9 @@ func handleCStore(
 	connState ConnectionState,
 	c *dimse.CStoreRq, data []byte,
 	cs *serviceCommandState) {
+	// Add AE titles to connection state
+	connState.CalledAETitle = cs.CalledAETitle
+	connState.CallingAETitle = cs.CallingAETitle
 	status := dimse.Status{Status: dimse.StatusUnrecognizedOperation}
 	if cb != nil {
 		status = cb(
@@ -386,7 +389,9 @@ type CMoveCallback func(
 type ConnectionState struct {
 	// TLS connection state. It is nonempty only when the connection is set up
 	// over TLS.
-	TLS tls.ConnectionState
+	TLS            tls.ConnectionState
+	CalledAETitle  string
+	CallingAETitle string
 }
 
 // CEchoCallback implements C-ECHO callback. It typically just returns

--- a/statemachine.go
+++ b/statemachine.go
@@ -182,11 +182,16 @@ var actionAe3 = &stateAction{"AE-3", "Issue A-ASSOCIATE confirmation (accept) pr
 		stopTimer(sm)
 		v := event.pdu.(*pdu.AAssociate)
 		doassert(v.Type == pdu.TypeAAssociateAc)
+		// since these are otherwise 16 bytes wide,
+		sm.CalledAETitle = strings.TrimSpace(v.CalledAETitle)
+		sm.CallingAETitle = strings.TrimSpace(v.CallingAETitle)
 		err := sm.contextManager.onAssociateResponse(v.Items)
 		if err == nil {
 			sm.upcallCh <- upcallEvent{
-				eventType: upcallEventHandshakeCompleted,
-				cm:        sm.contextManager,
+				eventType:      upcallEventHandshakeCompleted,
+				cm:             sm.contextManager,
+				CalledAETitle:  v.CalledAETitle,
+				CallingAETitle: v.CallingAETitle,
 			}
 			return sta06
 		}
@@ -226,6 +231,8 @@ otherwise issue A-ASSOCIATE-RJ-PDU and start ARTIM timer`,
 	func(sm *stateMachine, event stateEvent) stateType {
 		stopTimer(sm)
 		v := event.pdu.(*pdu.AAssociate)
+		sm.CalledAETitle = strings.TrimSpace(v.CalledAETitle)
+		sm.CallingAETitle = strings.TrimSpace(v.CallingAETitle)
 		if v.ProtocolVersion != 0x0001 {
 			dicomlog.Vprintf(0, "dicom.stateMachine(%s): Wrong remote protocol version 0x%x", sm.label, v.ProtocolVersion)
 			rj := pdu.AAssociateRj{Result: 1, Source: 2, Reason: 2}
@@ -263,10 +270,15 @@ otherwise issue A-ASSOCIATE-RJ-PDU and start ARTIM timer`,
 	}}
 var actionAe7 = &stateAction{"AE-7", "Send A-ASSOCIATE-AC PDU",
 	func(sm *stateMachine, event stateEvent) stateType {
-		sendPDU(sm, event.pdu.(*pdu.AAssociate))
+		v := event.pdu.(*pdu.AAssociate)
+		sm.CalledAETitle = strings.TrimSpace(v.CalledAETitle)
+		sm.CallingAETitle = strings.TrimSpace(v.CallingAETitle)
+		sendPDU(sm, v)
 		sm.upcallCh <- upcallEvent{
-			eventType: upcallEventHandshakeCompleted,
-			cm:        sm.contextManager,
+			eventType:      upcallEventHandshakeCompleted,
+			cm:             sm.contextManager,
+			CalledAETitle:  v.CalledAETitle,
+			CallingAETitle: v.CallingAETitle,
 		}
 		return sta06
 	}}
@@ -537,6 +549,10 @@ type upcallEvent struct {
 
 	command dimse.Message
 	data    []byte
+
+	// AE titles from the association handshake. Set for upcallEventHandshakeCompleted.
+	CalledAETitle  string
+	CallingAETitle string
 }
 
 type stateEventDIMSEPayload struct {
@@ -753,6 +769,10 @@ type stateMachine struct {
 
 	// For assembling DIMSE command from multiple P_DATA_TF fragments.
 	commandAssembler dimse.CommandAssembler
+
+	// AE titles from the A-ASSOCIATE PDU. Set during association handshake.
+	CalledAETitle  string
+	CallingAETitle string
 
 	// Only for testing.
 	faults FaultInjector


### PR DESCRIPTION
# When merged, this PR will

Expose `CalledAETitle` and `CallingAETitle` in netdicom service provider's `onCStore` callback, in the ConnectionState object.


## Why
We needed a way to access calling/called AEs inside our application code. 

## How
The library creates a fresh, separate state machine for each new incoming TCP connection. As such, it should be relatively safe to store AEs at the state machine level. This PR implements exactly that - grabs AE titles from the association handshake, stores them in the statemachine struct and propagates them down to a struct that is passed to userland handlers.

I added a test that demonstrates this works both with SU re-use s well as separate SU-s for sending two files.